### PR TITLE
Build man page as install fails in its absence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ submodule_check:
 submodules:
 	-test -d .git -a .gitmodules -a -f Makefile.git && $(MAKE) -f Makefile.git submodules
 
-all: submodule_check $(BUILDDIR)manifest.ttl $(BUILDDIR)$(LV2NAME).ttl $(targets) $(JACKAPP)
+all: submodule_check $(BUILDDIR)manifest.ttl $(BUILDDIR)$(LV2NAME).ttl $(targets) $(JACKAPP) man
 
 $(BUILDDIR)manifest.ttl: lv2ttl/manifest.ttl.in lv2ttl/manifest.gui.in Makefile
 	@mkdir -p $(BUILDDIR)


### PR DESCRIPTION
Makefile:
Build man page in "all" target, as install target fails in its absence otherwise.

Fix #1 