### PR TITLE
Add defaults for BINDIR and MANDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 #!/usr/bin/make -f
 PREFIX ?= /usr/local
 LV2DIR ?= $(PREFIX)/lib/lv2
+BINDIR ?= $(PREFIX)/bin
+MANDIR ?= $(PREFIX)/share/man/man1
 
 PKG_CONFIG ?= pkg-config
 STRIP ?= strip


### PR DESCRIPTION
Makefile:
Set defaults for BINDIR and MANDIR as files are otherwise installed to the root directory.

Fixes #3